### PR TITLE
jiin / 문자열 내 p와 y의 개수

### DIFF
--- a/jiin/200211_문자열내p와y의개수.js
+++ b/jiin/200211_문자열내p와y의개수.js
@@ -1,0 +1,12 @@
+const solution = (s) => { //'pPoooyY' , 'Pyy'
+    let p=0;
+    let y=0;
+    for(let i=0; i<s.length; i++){
+        if(s[i]==='p'||s[i]==='P'){
+            p++;
+        }else if(s[i]==='y'||s[i]==='Y'){
+            y++;
+        }
+    }
+    return p===y?true:false; //true, false
+}


### PR DESCRIPTION
### 풀이한 문제
[문자열 내 p와 y의 개수](https://programmers.co.kr/learn/courses/30/lessons/12916)

### 문제 풀이 방법
문자열 s에 for문을 돌려 만약 s의 i번째 문자가 p||P일 경우 변수 p에 1을 더하고, y||Y일 경우 변수 y에 1을 더해 최종적으로 p와 y의 값을 비교하여 결과를 return 했다.

### issue
문자열 s를 모두 대문자로 바꾸는 toUpperCase를 돌려주고 코드를 짰으면 더 깔끔하게 짤 수 있었을 것 같다.
다른 사람 문제 풀이를 보니까 다들 기상천외한 방법을 써서 재밌음... 대문자 처리한 s에 split을 돌려 해당 배열의 수를 비교하는 풀이법도 있었는데 잼섯다 split을 그런데 쓰다니 ...