### PR TITLE
jiin / valid-anagram & rotate-array & missing-number 

### DIFF
--- a/jiin/200306_missing-number.js
+++ b/jiin/200306_missing-number.js
@@ -1,0 +1,13 @@
+const missingNumber = (nums) => { //[3,0,1]
+    nums = nums.sort((a,b)=>{
+        return a-b;
+    })
+    if(nums[0]!==0){
+            return 0;
+    }
+    for(let i = 0; i<nums.length; i++){
+        if((nums[i]+1)===nums[i+1]){
+            console.log(i);
+        }else return nums[i]+1; //2
+    }
+};

--- a/jiin/200306_rotate-array.js
+++ b/jiin/200306_rotate-array.js
@@ -1,0 +1,8 @@
+const rotate = (nums, k) => { //[1,2,3,4,5,6,7],3
+    for(let i=0; i<k; i++){
+        let insert_num = nums[nums.length-1];
+        nums.splice(nums.length-1,1);
+        nums.unshift(insert_num);
+    }
+    return nums;   //[5,6,7,1,2,3,4]
+};

--- a/jiin/200306_valid-anagram.js
+++ b/jiin/200306_valid-anagram.js
@@ -1,0 +1,7 @@
+const isAnagram = (s, t) => { //"anagram","nagaram"
+    s = s.split('').sort().join('');
+    t = t.split('').sort().join('');
+    if(s===t){
+        return true // true
+    }else return false; 
+};


### PR DESCRIPTION
(1)
### 풀이한 문제
[valid-anagram](https://leetcode.com/problems/valid-anagram/submissions/)

### 문제 풀이 방법
s와 t를 split을 써서 배열로 만들고 sort를 적용한 후, join을 사용하여 다시 문자열로 합쳐주었다.
이후 두 문자열이 같은지를 비교하여 true/false 리턴

### issue
처음에 배열로 값을 비교하니까 제대로 된 결과가 뜨지 않았다.. 배열이라 참조값을 비교해서 그러나보다 하고 문자열로 만들어서 비교하니 제대로 된 값이 떴다.. 너무 금방 끝나서 양심상 다른 하나를 더 풀자고 결심..


(2)
### 풀이한 문제
[rotate-array](https://leetcode.com/problems/rotate-array/submissions/)

### 문제 풀이 방법
k만큼 반복하여 nums 배열의 가장 마지막 수를 삭제하고 그 수를 unshift를 사용하여 맨 앞에 위치하도록 했다.

### issue
unshift를 거의 처음 써본것 같다.. 이것도 너무 금방 끝나버려서 양심상 다른 문제를 더 하자 결심..


(3)
### 풀이한 문제
[missing-number](https://leetcode.com/problems/missing-number/submissions/)

### 문제 풀이 방법
우선 nums 배열을 오름차순으로 정렬하였다. (sort를 사용) 예제를 보면 정렬된 nums 배열은 0부터 시작하는 듯 하니 만약 처음 시작하는 수가 0이 아니면 0을 리턴하도록 했다. nums의 길이만큼 for문으로 반복시켜, i번째 숫자에 1을 더한 값이 i+1번째 숫자와 같지 않다면 그 사이 숫자가 빠진 것이므로 i번째 숫자에 1을 더한 값을 리턴시킨다.

### issue
예외사항이 생기는게 배열이 0으로 시작될 때가 아닌 때인것 같아서 저렇게 기록했는데 아리까리하다..